### PR TITLE
Add tailwind react components

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,8 @@
         "**/node_modules/**"
       ],
       "message": "chore(release): publish",
-      "registry": "https://registry.npmjs.org/"
+      "registry": "https://registry.npmjs.org/",
+      "contents": "packages/tailwind-react-components"
     }
   }
 }

--- a/packages/tailwind-react-components/README.md
+++ b/packages/tailwind-react-components/README.md
@@ -4,8 +4,15 @@
 
 ## Usage
 
-```
-const tailwindReactComponents = require('tailwind-react-components');
+```ts
+import { RButton } from '@ritro-ui-tailwind';
 
-// TODO: DEMONSTRATE API
+// Example usage of RButton component
+const App = () => (
+  <div>
+    <RButton label="Click me" onClick={() => alert('Button clicked!')} />
+  </div>
+);
+
+export default App;
 ```

--- a/packages/tailwind-react-components/package.json
+++ b/packages/tailwind-react-components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tailwind-react-components",
+  "name": "@ritro-ui-tailwind",
   "version": "1.0.0",
   "description": "React components built using tailwind",
   "author": "sujaykundu777 <sujaykundu777@gmail.com>",

--- a/packages/tailwind-react-components/src/index.ts
+++ b/packages/tailwind-react-components/src/index.ts
@@ -1,0 +1,3 @@
+import Button from './components/Button';
+
+export { Button };


### PR DESCRIPTION
Update the package to allow importing components using `@ritro-ui-tailwind`.

* **package.json**
  - Update the `name` field to `@ritro-ui-tailwind`.

* **README.md**
  - Add usage instructions for importing components using `@ritro-ui-tailwind`.

* **index.ts**
  - Export the `Button` component.

* **lerna.json**
  - Add configuration for publishing the `tailwind-react-components` package under the `@ritro-ui-tailwind` namespace.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sujaykundu777/ritro-ui-components?shareId=03e9000b-0809-41db-a04d-e7374f147417).